### PR TITLE
Fix rebuild_latest

### DIFF
--- a/postgres.pl
+++ b/postgres.pl
@@ -462,7 +462,7 @@ sub build
     print "$config_bin $configopt\n";
 
     # Cleanup the CONFIGOPTS depending on the version
-    $configopt=cleanup_configopts($configopt,$version);
+    $configopt=cleanup_configopts($configopt,$tobuild);
 
     system_or_confess("$config_bin $configopt");
     if ($make_check)

--- a/postgres.pl
+++ b/postgres.pl
@@ -729,14 +729,23 @@ sub rebuild_latest
     {
         my $already_compiled=0;
         my ($major1,$major2)=major_minor($version);
-        my @olddirs=<$work_dir/postgresql-${major1}.${major2}*>;
+        my @olddirs;
+        if ($major2 != 0)
+        {
+            # !0 means that's an old (pre 10) versioning
+            @olddirs=<$work_dir/postgresql-${major1}.${major2}*>;
+        }
+        else
+        {
+            @olddirs=<$work_dir/postgresql-${major1}*>;
+        }
         # olddirs will look like /home/marc/postgres/postgresql-9.3.0
         foreach my $olddir(@olddirs)
         {
             next if ($olddir =~ /dev$/ or $olddir =~ /review$/);
             next unless (-d $olddir);
 
-            $olddir=~ /(\d+\.\d+\.\d+)$/ or confess "Weird directory name: $olddir\n";
+            $olddir=~ /(\d+\.\d+(\.\d+)?)$/ or confess "Weird directory name: $olddir\n";
             my $oldversion=$1;
 
             if (compare_versions($oldversion,$version)==0)


### PR DESCRIPTION
Serves me well to use a global variable. $version wasn't initialized in
case you do a rebuild_latest without having set a version beforehand.
And could fail badly instead if you had

Make the cleanup of directories work again too